### PR TITLE
Caught "Content-Type: " (i.e. empty/illegal content-type header)

### DIFF
--- a/lib/rmail/header.rb
+++ b/lib/rmail/header.rb
@@ -533,8 +533,9 @@ module RMail
     # executed and its return value is returned.  If no block is passed,
     # the value of the +default+ argument is returned.
     def content_type(default = nil)
-      if value = self['content-type']
-	value.strip.split(/\s*;\s*/)[0].downcase
+      content_type = self['content-type']
+      if content_type && content_type.length > 0
+	content_type.strip.split(/\s*;\s*/)[0].downcase
       else
 	if block_given?
           yield

--- a/test/testheader.rb
+++ b/test/testheader.rb
@@ -776,6 +776,10 @@ EOF
     h.delete('content-type')
     h['content-type'] = ' foo/html   ; charset=ISO-8859-1'
     assert_equal("foo/html", h.content_type)
+
+    h = RMail::Header.new
+    h['content-type'] = ''
+    assert_equal(nil, h.content_type)
   end
 
   def test_media_type


### PR DESCRIPTION
and stopped it from throwing NoMethodError on a nil.

(caused my sup to crash constantly once a message like this was in the database & it tried to read the thread)
